### PR TITLE
set buffersize of embeddings endpoint to 512kb

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -490,7 +490,7 @@ func (o *Ollama) newGenerateEmbeddingsFunc() GenerateEmbeddingsFunc {
 			f(&req)
 		}
 
-		body, err := o.stream(http.MethodPost, "/api/embeddings", req, 0, nil)
+		body, err := o.stream(http.MethodPost, "/api/embeddings", req, 512000, nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR fixes a bug where the `GenerateEmbeddings` function would call `stream` with a max buffer size of 0. This would cause stream to read 0 bytes, break the loop early, and return with an empty body, which causes a panic. Instead, we set the maxBufferSize to 512kb.

The lines from ollama.go (L126-136). `GenerateEmbeddings` calls this function with `maxBufferSize` as 0.
```go
	for {
		buf := make([]byte, maxBufferSize)
		n, err := resp.Body.Read(buf)
		if err != nil && err != io.EOF {
			return nil, err
		}

		if n == 0 {
			break
		}

```

The lines from function.go (L488-504). `bodyTo` is then called with an empty body, which panics
```go
		req := GenerateEmbeddingsRequestBuilder{}
		for _, f := range builder {
			f(&req)
		}

		body, err := o.stream(http.MethodPost, "/api/embeddings", req, 512000, nil)
		if err != nil {
			return nil, err
		}

		r, err := bodyTo[GenerateEmbeddingsResponse](body[0])
		if err != nil {
			return nil, err
		}

		return r, nil

```